### PR TITLE
NSDS-1951: Refactor to auto build oraclelinux and centos7 docker images

### DIFF
--- a/build_docker.sh
+++ b/build_docker.sh
@@ -10,7 +10,7 @@ ORG=$2
 BRANCH=$3
 
 # build dev images
-docker build --rm --force-rm --build-arg ORG=${ORG} --build-arg BRANCH=${BRANCH} \
-  -t hysds/dev:${TAG} -f docker/Dockerfile .
-docker build --rm --force-rm --build-arg ORG=${ORG} --build-arg BRANCH=${BRANCH} \
-  -t hysds/cuda-dev:${TAG} -f docker/Dockerfile.cuda .
+docker build --rm --force-rm --progress=plain --build-arg TAG=${TAG} --build-arg ORG=${ORG} \
+  --build-arg BRANCH=${BRANCH} -t hysds/dev:${TAG} -f docker/Dockerfile .
+docker build --rm --force-rm --progress=plain --build-arg TAG=${TAG} --build-arg ORG=${ORG} \
+  --build-arg BRANCH=${BRANCH} -t hysds/cuda-dev:${TAG} -f docker/Dockerfile.cuda .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM hysds/base:latest
+ARG TAG=latest
+FROM hysds/base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
 LABEL description "Base HySDS image for development"

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,4 +1,5 @@
-FROM hysds/cuda-base:latest
+ARG TAG=latest
+FROM hysds/cuda-base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"
 LABEL description "CUDA Base HySDS image for development"

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir --depth 1
 fi
 
 
@@ -85,7 +85,7 @@ site_pp=$mod_dir/site.pp
 
 # check that module is here; if not, export it
 if [ ! -d $mod_dir ]; then
-  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir
+  $git_cmd clone --single-branch -b $BRANCH $git_loc $mod_dir --depth 1
 fi
 
 


### PR DESCRIPTION
Refactored such that it will allow us to build the oraclelinux and centos7 docker images automatically. Changes were based off of the `develop` branch.

```
(base) MT-204713:swot-pcm mcayanan$ docker images | grep "hysds/dev"
hysds/dev             20220224          eaf5e25dca25   5 days ago     3.07GB
hysds/dev             develop-centos7   eaf5e25dca25   5 days ago     3.07GB
(base) MT-204713:swot-pcm mcayanan$ docker images | grep "hysds/cuda-dev"
hysds/cuda-dev        20220301          47efb2da0939   3 hours ago    3.25GB
hysds/cuda-dev        develop-centos7   47efb2da0939   3 hours ago    3.25GB
```

```
(base) MT-204713:swot-pcm mcayanan$ docker run -it hysds/dev:develop-centos7 /bin/bash
ops@91af14f13e61:~$ more /etc/redhat-release 
CentOS Linux release 7.9.2009 (Core)
ops@91af14f13e61:~$ exit
exit
(base) MT-204713:swot-pcm mcayanan$ docker run -it hysds/cuda-dev:develop-centos7 /bin/bash
ops@04782e7717b5:~$ more /etc/redhat-release 
CentOS Linux release 7.9.2009 (Core)
ops@04782e7717b5:~$ 
```