### PR TITLE
HC-522-update: Updates to support moving away from the OPS user in the Core containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG=latest
+ARG TAG=HC-522-update
 FROM hysds/base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,4 +1,4 @@
-ARG TAG=latest
+ARG TAG=HC-522-update
 FROM hysds/cuda-base:${TAG}
 
 MAINTAINER Gerald Manipon (pymonger) "pymonger@gmail.com"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # set HOME explicitly
-export HOME=/home/ops
+export HOME=/root
 
 # get group id
 GID=$(id -g)

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,13 +8,13 @@ export HOME=/root
 GID=$(id -g)
 
 # update user and group ids
-gosu 0:0 groupmod -g $GID ops 2>/dev/null
-gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
-gosu 0:0 usermod -aG docker ops 2>/dev/null
+#gosu 0:0 groupmod -g $GID ops 2>/dev/null
+#gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
+#gosu 0:0 usermod -aG docker ops 2>/dev/null
 
 # update ownership
-gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
-gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
+#gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
 
 # source bash profile
 source $HOME/.bash_profile

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -7,14 +7,9 @@ export HOME=/root
 # get group id
 GID=$(id -g)
 
-# update user and group ids
-#gosu 0:0 groupmod -g $GID ops 2>/dev/null
-#gosu 0:0 usermod -u $UID -g $GID ops 2>/dev/null
-#gosu 0:0 usermod -aG docker ops 2>/dev/null
-
-# update ownership
-#gosu 0:0 chown -R $UID:$GID $HOME 2>/dev/null || true
-#gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+if [ -e /var/run/docker.sock ]; then
+  gosu 0:0 chown -R $UID:$GID /var/run/docker.sock 2>/dev/null || true
+fi
 
 # source bash profile
 source $HOME/.bash_profile


### PR DESCRIPTION
This PR updates the Dockerfile and entrypoint scripts such that it supports the moving away from the OPS user that the Core containers would default to.


CircleCI passed when building containers under the HC-522-update tag:

![image](https://github.com/user-attachments/assets/2154a661-b3cb-4505-91e5-8506c4a28349)

Will need to remove the following kludges before merging:

- https://github.com/hysds/puppet-hysds_dev/compare/develop...HC-522-update?expand=1#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcR1
- https://github.com/hysds/puppet-hysds_dev/compare/develop...HC-522-update?expand=1#diff-aed8cad212e1551c709b65927fda3650042bbaab1f8618b74bb9cfbb7ed440fdR1